### PR TITLE
Output cucumber runner results directy to stdio

### DIFF
--- a/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
+++ b/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
@@ -33,8 +33,8 @@ import scala.util.Try
 
 /**
   * CucumberPlugin
-  *   This class implements the AutoPlugin interface. The Cucumber plugin
-  *   will invoke Cucumber for Scala.
+  * This class implements the AutoPlugin interface. The Cucumber plugin
+  * will invoke Cucumber for Scala.
   */
 object CucumberPlugin extends AutoPlugin {
 
@@ -59,7 +59,7 @@ object CucumberPlugin extends AutoPlugin {
   val cucumberTestReports = settingKey[File]("The location for test reports")
 
   /** Any additional properties. */
-  val envProperties = SettingKey[Map[String,String]]("properties")
+  val envProperties = SettingKey[Map[String, String]]("properties")
 
   /**
     * Where glue code (step definitions, hooks and plugins)
@@ -68,20 +68,20 @@ object CucumberPlugin extends AutoPlugin {
   val glue = SettingKey[String]("cucumber-glue")
 
   /** A beforeAll hook for Cucumber tests.                      */
-  val beforeAll = SettingKey[()=>Unit]("cucumber-before")
+  val beforeAll = SettingKey[() => Unit]("cucumber-before")
 
   /** An afterAll hook for Cucumber tests.                      */
-  val afterAll = SettingKey[()=>Unit]("cucumber-after")
+  val afterAll = SettingKey[() => Unit]("cucumber-after")
 
   /** Default hook for beforeAll, afterAll.                     */
-  private def noOp() : Unit = {}
+  private def noOp(): Unit = {}
 
   /**
     * Defines the project settings for this plugin.
     *
     * @return a Sequence of SBT settings.
     */
-  override def projectSettings : Seq[Setting[_]] = Seq (
+  override def projectSettings: Seq[Setting[_]] = Seq(
 
     envProperties := Map.empty,
 
@@ -89,27 +89,28 @@ object CucumberPlugin extends AutoPlugin {
 
       val args: Seq[String] = spaceDelimited("<arg>").parsed
 
-      val outputStrategy = LoggedOutput(streams.value.log)
+      val logger = streams.value.log
 
       val classPath = ((fullClasspath in Test)
-                map { cp => cp.toList.map(_.data)}).value
+        map { cp => cp.toList.map(_.data) }).value
 
       val cucumberParams = CucumberParameters(
-                                  dryRun.value,
-                                  features.value,
-                                  monochrome.value,
-                                  plugin.value,
-                                  glue.value,
-                                  args.toList)
+        dryRun.value,
+        features.value,
+        monochrome.value,
+        plugin.value,
+        glue.value,
+        args.toList
+      )
 
       import scala.collection.JavaConverters._
       val envParams = System.getenv.asScala.toMap ++ envProperties.value
 
       beforeAll.value
-      val result = run(classPath,envParams,mainClass.value,cucumberParams,outputStrategy)
+      val result = run(classPath, envParams, mainClass.value, cucumberParams, logger)
       afterAll.value
       if (result != 0) {
-          throw new IllegalStateException("Cucumber did not succeed and returned error =" + result)
+        throw new IllegalStateException("Cucumber did not succeed and returned error =" + result)
       }
     },
 
@@ -132,13 +133,13 @@ object CucumberPlugin extends AutoPlugin {
     afterAll := noOp
   )
 
-
   def run(classPath: List[File],
           env: Map[String, String],
           mainClass: String,
           cucumberParams: CucumberParameters,
-          outputStrategy: OutputStrategy) = Try {
-      Jvm(classPath,env).run(mainClass,cucumberParams.toList,outputStrategy)
+          logger: Logger): Int =
+    Try {
+      Jvm(classPath, env).run(mainClass, cucumberParams.toList, logger)
     }.recover {
       case t: Throwable =>
         println(s"[CucumberPlugin] Caught exception: ${t.getMessage}")

--- a/src/main/scala/com/waioeka/sbt/Jvm.scala
+++ b/src/main/scala/com/waioeka/sbt/Jvm.scala
@@ -31,47 +31,46 @@ import java.lang.management.ManagementFactory
 import org.apache.commons.lang3.SystemUtils
 import sbt._
 
-
-case class Jvm(classPath: List[File], envParams : Map[String, String]) {
+case class Jvm(classPath: List[File], envParams: Map[String, String]) {
 
   /** Classpath separator, must be ';' for Windows, otherwise : */
   private val sep = if (SystemUtils.IS_OS_WINDOWS) ";" else ":"
 
-
   /** Get the JVM options passed into SBT. */
+
   import scala.collection.JavaConverters._
+
   private val runtimeArgs = ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toVector
 
   /** The Jvm parameters. */
-  private val jvmArgs : Vector[String]
-          = Vector("-classpath", classPath map(_.toPath) mkString sep) ++ runtimeArgs
+  private val jvmArgs: Vector[String]
+  = Vector("-classpath", classPath map (_.toPath) mkString sep) ++ runtimeArgs
 
   /**
     * Invoke the main class.
     *
-    * @param mainClass        the class name containing the main method.
-    * @param parameters       the parameters to pass to the main method.
-    * @param outputStrategy   the SBT output strategy.
-    * @return  the return code of the Jvm.
+    * @param mainClass      the class name containing the main method.
+    * @param parameters     the parameters to pass to the main method.
+    * @param logger         SBT logger for debugging.
+    * @return the return code of the Jvm.
     */
-  def run(mainClass : String, parameters : List[String], outputStrategy: OutputStrategy) : Int = {
+  def run(mainClass: String, parameters: List[String], logger: Logger): Int = {
 
-    val logger = outputStrategy.asInstanceOf[LoggedOutput].logger
-    val args =  jvmArgs :+ mainClass
+    val args = jvmArgs :+ mainClass
 
     logger.debug(s"args ${args mkString " "}, env: $envParams, parameters: ${parameters.mkString(",")}")
 
-    val opts = ForkOptions(javaHome = None,
-                outputStrategy = Some(outputStrategy),
-                bootJars = Vector.empty,
-                workingDirectory = None,
-                runJVMOptions = args,
-                connectInput = false,
-                envVars = envParams)
+    val opts = ForkOptions(
+      javaHome = None,
+      outputStrategy = Some(StdoutOutput),
+      bootJars = Vector.empty,
+      workingDirectory = None,
+      runJVMOptions = args,
+      connectInput = false,
+      envVars = envParams
+    )
 
-
-    Fork.java(opts,parameters)
+    Fork.java(opts, parameters)
   }
-
 
 }


### PR DESCRIPTION
Previously used LoggingOutput is a inconvenient for story TDD cycle,
since it prepends all output with log level and prevents from
quickly copy pasting generated steps code, for example:
```
[info] Then("""^result should be (\d+) with mistype$"""){ (arg0:Int) =>
[info]   //// Write code here that turns the phrase above into concrete actions
[info]   throw new PendingException()
[info] }
```

after the change the output would be as before minus the prepended log level, for example:
```
[info] Compiling 1 Scala source to /Volumes/Arturas/Projects/scala-cucumber-example/target/scala-2.12/classes ...
[info] Done compiling.
[info] Compiling 2 Scala sources to /Volumes/Arturas/Projects/scala-cucumber-example/target/scala-2.12/test-classes ...
[info] Done compiling.
@my-tag
Feature: Multiplication
  In order to avoid making mistakes
  As a dummy
  I want to multiply numbers

  @my-tag
  Scenario: Multiply two variables      # features/multiplication.feature:7
    Given a variable x equals 2         # MultiplicationSteps.scala:11
    And a variable y equals 3           # MultiplicationSteps.scala:15
    When I multiply x and y             # MultiplicationSteps.scala:19
    Then result should be 5             # MultiplicationSteps.scala:23
      org.scalatest.exceptions.TestFailedException: 6 was not equal to 5
	at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:346)
	at org.scalatest.Matchers$AnyShouldWrapper.shouldBe(Matchers.scala:6864)
	at example.steps.MultiplicationSteps.$anonfun$new$4(MultiplicationSteps.scala:24)
	at example.steps.MultiplicationSteps.$anonfun$new$4$adapted(MultiplicationSteps.scala:23)
	at cucumber.api.scala.ScalaDsl$StepBody$$anonfun$apply$2.applyOrElse(ScalaDsl.scala:100)
	at cucumber.api.scala.ScalaDsl$StepBody$$anonfun$apply$2.applyOrElse(ScalaDsl.scala:98)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:34)
	at cucumber.runtime.scala.ScalaStepDefinition.execute(ScalaStepDefinition.scala:70)
	at cucumber.runtime.StepDefinitionMatch.runStep(StepDefinitionMatch.java:40)
	at cucumber.api.TestStep.executeStep(TestStep.java:102)
	at cucumber.api.TestStep.run(TestStep.java:83)
	at cucumber.api.TestCase.run(TestCase.java:58)
	at cucumber.runner.Runner.runPickle(Runner.java:80)
	at cucumber.runtime.Runtime.runFeature(Runtime.java:119)
	at cucumber.runtime.Runtime.run(Runtime.java:104)
	at cucumber.api.cli.Main.run(Main.java:36)
	at cucumber.api.cli.Main.main(Main.java:18)
	at ✽.result should be 5(features/multiplication.feature:11)

    And result should be 6 with mistype # null

Failed scenarios:
features/multiplication.feature:7 # Multiply two variables

1 Scenarios (1 failed)
5 Steps (1 failed, 1 undefined, 3 passed)
0m0.209s

org.scalatest.exceptions.TestFailedException: 6 was not equal to 5
	at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:346)
	at org.scalatest.Matchers$AnyShouldWrapper.shouldBe(Matchers.scala:6864)
	at example.steps.MultiplicationSteps.$anonfun$new$4(MultiplicationSteps.scala:24)
	at example.steps.MultiplicationSteps.$anonfun$new$4$adapted(MultiplicationSteps.scala:23)
	at cucumber.api.scala.ScalaDsl$StepBody$$anonfun$apply$2.applyOrElse(ScalaDsl.scala:100)
	at cucumber.api.scala.ScalaDsl$StepBody$$anonfun$apply$2.applyOrElse(ScalaDsl.scala:98)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:34)
	at cucumber.runtime.scala.ScalaStepDefinition.execute(ScalaStepDefinition.scala:70)
	at cucumber.runtime.StepDefinitionMatch.runStep(StepDefinitionMatch.java:40)
	at cucumber.api.TestStep.executeStep(TestStep.java:102)
	at cucumber.api.TestStep.run(TestStep.java:83)
	at cucumber.api.TestCase.run(TestCase.java:58)
	at cucumber.runner.Runner.runPickle(Runner.java:80)
	at cucumber.runtime.Runtime.runFeature(Runtime.java:119)
	at cucumber.runtime.Runtime.run(Runtime.java:104)
	at cucumber.api.cli.Main.run(Main.java:36)
	at cucumber.api.cli.Main.main(Main.java:18)
	at ✽.result should be 5(features/multiplication.feature:11)

You can implement missing steps with the snippets below:

Then("""^result should be (\d+) with mistype$"""){ (arg0:Int) =>
  //// Write code here that turns the phrase above into concrete actions
  throw new PendingException()
}
[error] java.lang.IllegalStateException: Cucumber did not succeed and returned error =1
[error] 	at com.waioeka.sbt.CucumberPlugin$.$anonfun$projectSettings$6(CucumberPlugin.scala:113)
[error] 	at com.waioeka.sbt.CucumberPlugin$.$anonfun$projectSettings$6$adapted(CucumberPlugin.scala:88)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:39)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:66)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:263)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:272)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:263)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:174)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[error] 	at java.lang.Thread.run(Thread.java:745)
[error] (cucumber) java.lang.IllegalStateException: Cucumber did not succeed and returned error =1
[error] Total time: 7 s, completed 28-Sep-2018 21:35:18
```
<img width="756" alt="screen shot 2018-09-28 at 21 40 53" src="https://user-images.githubusercontent.com/915284/46232470-42872100-c367-11e8-955c-d00b82384f30.png">
