### PR TITLE
CucumberPlugin.glue updated to .glues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The project _cucumber-plugin-example_ highlights how to use the plugin. You will
  
     enablePlugins(CucumberPlugin)
  
-    CucumberPlugin.glue := List("com/waioeka/sbt/")
+    CucumberPlugin.glues := List("com/waioeka/sbt/")
 
     // Any environment properties you want to override/set.
     CucumberPlugin.envProperties := Map("K"->"2049")


### PR DESCRIPTION
Although the example project already uses the updated key, the readme had a misleading bit with the old key name.