### PR TITLE
Update cucumber main class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+dist: trusty
 matrix:
   include:
   - env: SBT_VERSION="0.13.16"

--- a/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
+++ b/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
@@ -114,7 +114,7 @@ object CucumberPlugin extends AutoPlugin {
       }
     },
 
-    mainClass := "cucumber.api.cli.Main",
+    mainClass := "io.cucumber.core.cli.Main",
     dryRun := false,
     features := List("classpath:"),
     monochrome := false,


### PR DESCRIPTION
To get rid of deprecation warning.

Example output before fix (warning in red when `monochrome := false`):
```
[info] [info] Done compiling.
[error] Oct 29, 2019 8:20:40 PM cucumber.api.cli.Main run
[error] WARNING: You are using deprecated Main class. Please use io.cucumber.core.cli.Main
[info] @hello-world
[info] Feature: Hello World
```

Example output after fix:
```
[info] [info] Done compiling.
[info] @hello-world
[info] Feature: Hello World
```