### PR TITLE
Provide javaOptions setting key

### DIFF
--- a/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
+++ b/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
@@ -73,6 +73,9 @@ object CucumberPlugin extends AutoPlugin {
   /** An afterAll hook for Cucumber tests.                      */
   val afterAll = SettingKey[() => Unit]("cucumber-after")
 
+  /** The Java options */
+  val javaOptions = taskKey[Seq[String]]("Options passed to a new JVM when forking.")
+
   /** Default hook for beforeAll, afterAll.                     */
   private def noOp(): Unit = {}
 
@@ -107,7 +110,7 @@ object CucumberPlugin extends AutoPlugin {
       val envParams = System.getenv.asScala.toMap ++ envProperties.value
 
       beforeAll.value
-      val result = run(classPath, envParams, mainClass.value, cucumberParams, logger)
+      val result = run(classPath, envParams, mainClass.value, javaOptions.value, cucumberParams, logger)
       afterAll.value
       if (result != 0) {
         throw new IllegalStateException("Cucumber did not succeed and returned error =" + result)
@@ -136,10 +139,11 @@ object CucumberPlugin extends AutoPlugin {
   def run(classPath: List[File],
           env: Map[String, String],
           mainClass: String,
+          javaOptions: Seq[String],
           cucumberParams: CucumberParameters,
           logger: Logger): Int =
     Try {
-      Jvm(classPath, env).run(mainClass, cucumberParams.toList, logger)
+      Jvm(classPath, env, javaOptions).run(mainClass, cucumberParams.toList, logger)
     }.recover {
       case t: Throwable =>
         println(s"[CucumberPlugin] Caught exception: ${t.getMessage}")

--- a/src/main/scala/com/waioeka/sbt/Jvm.scala
+++ b/src/main/scala/com/waioeka/sbt/Jvm.scala
@@ -31,20 +31,14 @@ import java.lang.management.ManagementFactory
 import org.apache.commons.lang3.SystemUtils
 import sbt._
 
-case class Jvm(classPath: List[File], envParams: Map[String, String]) {
+case class Jvm(classPath: List[File], envParams: Map[String, String], javaOptions: Seq[String]) {
 
   /** Classpath separator, must be ';' for Windows, otherwise : */
   private val sep = if (SystemUtils.IS_OS_WINDOWS) ";" else ":"
 
-  /** Get the JVM options passed into SBT. */
-
-  import scala.collection.JavaConverters._
-
-  private val runtimeArgs = ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toVector
-
   /** The Jvm parameters. */
   private val jvmArgs: Vector[String]
-  = Vector("-classpath", classPath map (_.toPath) mkString sep) ++ runtimeArgs
+  = Vector("-classpath", classPath map (_.toPath) mkString sep) ++ javaOptions
 
   /**
     * Invoke the main class.


### PR DESCRIPTION
This commit allows for javaOptions being provided to the JVM executing
the Cucumber tests. It comes in handy when passing debug args

Example of usage would be

```scala
val myproj = project
   .enablePlugins(CucumberPlugin)
  .settings(
     // ... more settings here
     CucumberPlugin.javaOptions := Seq("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"),
  )
```

