### PR TITLE
Use Cucumber 6.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,101 +18,95 @@
 The Cucumber plugin provides a new sbt command, allowing you to run just your Cucumber tests using `sbt cucumber`.
 
 The plugin can be used if you want a separate command to run Cucumber tests and have your normal test framework ignore Cucumber tests.
+
 If you want to run Cucumber tests within a ScalaTest unit test framework see [here](https://github.com/lewismj/cucumber).
-
-## Latest change
-
-Please note this <a href="https://github.com/sbt/sbt-cucumber/pull/4/files">change</a> was merged in, to make the glue
-parameter a List, rather than String.
 
 ## Dependency Information
 
 ```scala
- addSbtPlugin("com.waioeka.sbt" % "cucumber-plugin" % "0.2.1")
- 
+ addSbtPlugin("com.waioeka.sbt" % "cucumber-plugin" % "0.3.0")
 ```
-Note, the latest version of the plugin is built using SBT 1.2.8.
+
+> **Note** The latest version of the plugin is built using SBT 1.2.8.
 
 ### Cucumber Plugin Example
 
 The project _cucumber-plugin-example_ highlights how to use the plugin. You will need to ensure that your `build.sbt` file defines both the dependencies and the 'glue' setting (i.e. where to find the step definitions).
 
-
 ```scala
+name := "cucumber-test"
+organization := "com.waioeka.sbt"
+version := "0.3.0"
 
-    name := "cucumber-test"
- 
-    organization := "com.waioeka.sbt"
- 
-    version := "0.2.1"
- 
-    libraryDependencies ++= Seq (
-    "io.cucumber" % "cucumber-core" % "4.3.0" % "test",
-    "io.cucumber" %% "cucumber-scala" % "4.3.0" % "test",
-    "io.cucumber" % "cucumber-jvm" % "4.3.0" % "test",
-    "io.cucumber" % "cucumber-junit" % "4.3.0" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.5" % "test")
- 
-    enablePlugins(CucumberPlugin)
- 
-    CucumberPlugin.glues := List("com/waioeka/sbt/")
+libraryDependencies ++= Seq (
+  "io.cucumber" % "cucumber-core" % "6.10.3" % "test",
+  "io.cucumber" %% "cucumber-scala" % "6.10.3" % "test",
+  "io.cucumber" % "cucumber-jvm" % "6.10.3" % "test",
+  "io.cucumber" % "cucumber-junit" % "6.10.3" % "test",
+  "org.scalatest" %% "scalatest" % "3.2.8" % "test")
 
-    // Any environment properties you want to override/set.
-    CucumberPlugin.envProperties := Map("K"->"2049")
+enablePlugins(CucumberPlugin)
+
+CucumberPlugin.glues := List("com.waioeka.sbt")
+
+// Any environment properties you want to override/set.
+CucumberPlugin.envProperties := Map("K"->"2049")
 ```
 
 Remember to set the `CucumberPlugin.glue` parameter to the sub directory in *test* that contains your Scala step definitions.
-In your *resources* directory, put in your feature files. 
 
-```cucumber 
-    @my-tag
-    Feature: Multiplication
-      In order to avoid making mistakes
-      As a dummy
-      I want to multiply numbers
- 
-    Scenario: Multiply two variables
-    Given a variable x with value 2
-    And a variable y with value 3
-    When I multiply x * y
-    Then I get 6
-``` 
+In your *resources* directory, put in your feature files.
 
-If you need to generate the stubs, just run `sbt cucumber` and you will get an
-error complaining about missing stubs. You can copy and paste the stub functions into your
-step implementation.
+```feature
+@my-tag
+Feature: Multiplication
+  In order to avoid making mistakes
+  As a dummy
+  I want to multiply numbers
+
+Scenario: Multiply two variables
+Given a variable x with value 2
+And a variable y with value 3
+When I multiply x * y
+Then I get 6
+```
+
+If you need to generate the stubs, just run `sbt cucumber` and you will get an error complaining about missing stubs. You can copy and paste the stub functions into your step implementation.
 
 You can now put in your stub implementation:
 
 ```scala
-    package com.waioeka.sbt
- 
-    import cucumber.api.scala.{ScalaDsl, EN}
-    import org.scalatest.Matchers
- 
-    /** AddAndMultiplySteps*/
-    class MultiplicationSteps extends ScalaDsl with EN with Matchers {
-      var x : Int = 0
-      var y : Int = 0
-      var z : Int = 0
- 
-      Given("""^a variable x with value (\d+)$""") { (arg0: Int) => x = arg0 }
- 
-      Given("""^a variable y with value (\d+)$""") { (arg0: Int) => y = arg0 }
- 
-      When("""^I multiply x \* y$""") { () => z = x * y }
- 
-      Then("""^I get (\d+)$""") { (arg0: Int) => z should be (arg0) }
-    }
+package com.waioeka.sbt
+
+import io.cucumber.scala.{EN, ScalaDsl}
+import org.scalatest.Matchers
+
+/** AddAndMultiplySteps*/
+class MultiplicationSteps extends ScalaDsl with EN with Matchers {
+  var x : Int = 0
+  var y : Int = 0
+  var z : Int = 0
+
+  Given("""^a variable x with value (\d+)$""") { (arg0: Int) => x = arg0 }
+
+  Given("""^a variable y with value (\d+)$""") { (arg0: Int) => y = arg0 }
+
+  When("""^I multiply x \* y$""") { () => z = x * y }
+
+  Then("""^I get (\d+)$""") { (arg0: Int) => z should be (arg0) }
+}
 ```
+
 To run the tests in standalone mode:
-```
+
+```shell
 sbt compile
 sbt cucumber
 ```
+
 You should see some output as follows:
 
-```
+```shell
 paeroa:cucumber-test lewismj$ sbt cucumber
 [info] Loading project definition from /Users/lewismj/waioeka/upa-plugins/cucumber-test/project
 [info] Set current project to cucumber-test (in build file:/Users/lewismj/waioeka/upa-plugins/cucumber-test/)
@@ -144,7 +138,7 @@ The results will be output in the following formats:
 
 Cucumber arguments may be supplied. For example, `sbt "cucumber --tags ~@my-tag"` will filter tagged feature files.
 
-```
+```shell
 [success] Total time: 1 s, completed 15-Jun-2016 09:23:22
 paeroa:cucumber-plugin-example lewismj$ sbt "cucumber --tags ~@my-tag"
 [info] Loading global plugins from /Users/lewismj/.sbt/0.13/plugins
@@ -152,11 +146,11 @@ paeroa:cucumber-plugin-example lewismj$ sbt "cucumber --tags ~@my-tag"
 [info] Set current project to cucumber-test (in build file:/Users/lewismj/github/cucumber/cucumber-plugin-example/)
 ** hello **
 [info] None of the features at [classpath:] matched the filters: [~@my-tag]
-[info] 
+[info]
 [info] 0 Scenarios
 [info] 0 Steps
 [info] 0m0.000s
-[info] 
+[info]
 ** goodbye **
 [success] Total time: 1 s, completed 15-Jun-2016 09:23:41
 ```
@@ -164,7 +158,16 @@ paeroa:cucumber-plugin-example lewismj$ sbt "cucumber --tags ~@my-tag"
 ## Properties
 
 In your `build.sbt` file you can now specify environment variables as follows:
+
 ```scala
-  CucumberPlugin.envProperties := Map("K"->"2049")
+CucumberPlugin.envProperties := Map("K"->"2049")
 ```
+
 The setting expects a type of `Map[String,String]`.
+
+## Changelog
+
+| Version | Summary                                                                                                                                           |
+|---------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.0   | The plugin now uses Cucumber 6.10.3                                                                                                               |
+| 0.2.0   | Please note this [change](https://github.com/sbt/sbt-cucumber/pull/4/files) was merged in, to make the glue parameter a List, rather than String. |

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val buildSettings = Seq(
   crossScalaVersions in ThisBuild := Seq(Scala11x, Scala12x),
   sbtPlugin := true,
   sbtVersion in Global := "1.2.8",
-  version := "0.2.1"
+  version := "0.3.0"
 )
 
 lazy val credentialSettings = Seq(
@@ -48,10 +48,10 @@ lazy val publishSettings = Seq(
 lazy val commonSettings = Seq(
   scalacOptions += "-target:jvm-1.8",
   libraryDependencies ++=  Seq (
-    "io.cucumber" % "cucumber-core" % "4.3.0",
-    "io.cucumber" %% "cucumber-scala" % "4.3.0",
-    "io.cucumber" % "cucumber-jvm" % "4.3.0" pomOnly(),
-    "io.cucumber" % "cucumber-junit" % "4.3.0",
+    "io.cucumber" % "cucumber-core" % "6.10.3",
+    "io.cucumber" %% "cucumber-scala" % "6.10.3",
+    "io.cucumber" % "cucumber-jvm" % "6.10.3" pomOnly(),
+    "io.cucumber" % "cucumber-junit" % "6.10.3",
     "org.apache.commons" % "commons-lang3" % "3.9",
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
     "org.scala-lang.modules" %% "scala-xml" % "1.2.0"),

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -4,14 +4,14 @@ organization := "com.waioeka.sbt"
 
 version := "0.0.6"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.13"
 
 libraryDependencies ++= Seq (
-        "io.cucumber" % "cucumber-core" % "4.3.0" % "test",
-        "io.cucumber" %% "cucumber-scala" % "4.3.0" % "test",
-        "io.cucumber" % "cucumber-jvm" % "4.3.0" % "test",
-        "io.cucumber" % "cucumber-junit" % "4.3.0" % "test",
-        "org.scalatest" %% "scalatest" % "3.0.1" % "test")
+        "io.cucumber" % "cucumber-core" % "6.10.3" % Test,
+        "io.cucumber" %% "cucumber-scala" % "6.10.3" % Test,
+        "io.cucumber" % "cucumber-jvm" % "6.10.3" % Test,
+        "io.cucumber" % "cucumber-junit" % "6.10.3" % Test,
+        "org.scalatest" %% "scalatest" % "3.2.8" % Test)
 
 enablePlugins(CucumberPlugin)
 
@@ -19,7 +19,7 @@ enablePlugins(CucumberPlugin)
 CucumberPlugin.envProperties := Map("K"->"2049")
 
 CucumberPlugin.monochrome := false
-CucumberPlugin.glues := List("com/waioeka/sbt/")
+CucumberPlugin.glues := List("com.waioeka.sbt")
 
 def before() : Unit = { println("beforeAll") }
 def after() : Unit = { println("afterAll") }

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.waioeka.sbt" % "cucumber-plugin" % "0.2.1")
+addSbtPlugin("com.waioeka.sbt" % "cucumber-plugin" % "0.3.0")

--- a/example/src/test/resources/cucumber.properties
+++ b/example/src/test/resources/cucumber.properties
@@ -1,0 +1,1 @@
+cucumber.publish.quiet=true

--- a/example/src/test/scala/com/waioeka/sbt/MultiplicationSteps.scala
+++ b/example/src/test/scala/com/waioeka/sbt/MultiplicationSteps.scala
@@ -25,9 +25,8 @@
 
 package com.waioeka.sbt
 
-import cucumber.api.scala.{ScalaDsl, EN}
-import org.scalatest.Matchers
-
+import io.cucumber.scala.{EN, ScalaDsl}
+import org.scalatest.matchers.should.Matchers
 
 /**
   * AddAndMultiplySteps

--- a/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
+++ b/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
@@ -114,7 +114,7 @@ object CucumberPlugin extends AutoPlugin {
       }
     },
 
-    mainClass := "cucumber.api.cli.Main",
+    mainClass := "io.cucumber.core.cli.Main",
     dryRun := false,
     features := List("classpath:"),
     monochrome := false,
@@ -124,7 +124,7 @@ object CucumberPlugin extends AutoPlugin {
       val cucumberDir = cucumberTestReports.value
       IO.createDirectory(cucumberDir)
       List(PrettyPlugin,
-        HtmlPlugin(cucumberDir),
+        HtmlPlugin(new File(cucumberDir, "cucumber.html")),
         JsonPlugin(new File(cucumberDir, "cucumber.json")),
         JunitPlugin(new File(cucumberDir, "junit-report.xml"))
       )


### PR DESCRIPTION
Hi, its a very nice plugin for Scala developers who want to use Cucumber as the implementation of their BDD style tests. But unfortunately its no longer compatible with latest Cucumber (6.x) as discussed in #15. 

I updated the plugin and I hope you happy with the change.

Cheers!