### PR TITLE
Customizable classpath and adding tags via sbt config

### DIFF
--- a/src/main/scala/com/waioeka/sbt/CucumberParameters.scala
+++ b/src/main/scala/com/waioeka/sbt/CucumberParameters.scala
@@ -37,7 +37,8 @@ import java.io.File
   * @param features       the path(s) to the features.
   * @param monochrome     whether or not to use monochrome output.
   * @param plugins        what plugin(s) to use.
-  * @param glues           where glue code is loaded from.
+  * @param glues          where glue code is loaded from.
+  * @param tags           what tag(s) to use.
   * @param additionalArgs additional arguments to pass through to Cucumber.
   */
 case class CucumberParameters(
@@ -46,6 +47,7 @@ case class CucumberParameters(
                                monochrome    : Boolean,
                                plugins       : List[Plugin],
                                glues         : List[String],
+                               tags          : List[String],
                                additionalArgs: List[String]) {
 
   /**
@@ -70,6 +72,7 @@ case class CucumberParameters(
       boolToParameter(monochrome,"monochrome") :::
       glues.flatMap(glue => Seq("--glue", glue)) :::
       plugins.map(_.toCucumberPlugin).flatMap(plugin => Seq("--plugin", plugin)) :::
+      tags.flatMap(tag => Seq("--tags", tag)) :::
       additionalArgs :::
       features
   }

--- a/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
+++ b/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
@@ -56,6 +56,9 @@ object CucumberPlugin extends AutoPlugin {
   /** What plugin(s) to use.                                      */
   val plugin = SettingKey[List[Plugin]]("cucumber-plugins")
 
+  /** What tag(s) to use. */
+  val tags = SettingKey[List[String]]("cucumber-tags")
+
   val cucumberTestReports = settingKey[File]("The location for test reports")
 
   /** Any additional properties. */
@@ -76,6 +79,9 @@ object CucumberPlugin extends AutoPlugin {
   /** The Java options */
   val javaOptions = taskKey[Seq[String]]("Options passed to a new JVM when forking.")
 
+  /** Classpath to be used by cucumber (defaults to test classpath). */
+  val classpath = taskKey[Classpath]("Classpath to be used by cucumber.")
+
   /** Default hook for beforeAll, afterAll.                     */
   private def noOp(): Unit = {}
 
@@ -94,8 +100,7 @@ object CucumberPlugin extends AutoPlugin {
 
       val logger = streams.value.log
 
-      val classPath = ((fullClasspath in Test)
-        map { cp => cp.toList.map(_.data) }).value
+      val classPath = (classpath map { cp => cp.toList.map(_.data) }).value
 
       val cucumberParams = CucumberParameters(
         dryRun.value,
@@ -103,6 +108,7 @@ object CucumberPlugin extends AutoPlugin {
         monochrome.value,
         plugin.value,
         glues.value,
+        tags.value,
         args.toList
       )
 
@@ -121,6 +127,7 @@ object CucumberPlugin extends AutoPlugin {
     dryRun := false,
     features := List("classpath:"),
     monochrome := false,
+    tags := Nil,
     cucumberTestReports := new File(new File(target.value, "test-reports"), "cucumber"),
     plugin := {
       import Plugin._
@@ -133,7 +140,8 @@ object CucumberPlugin extends AutoPlugin {
       )
     },
     beforeAll := noOp,
-    afterAll := noOp
+    afterAll := noOp,
+    classpath := (fullClasspath in Test).value
   )
 
   def run(classPath: List[File],


### PR DESCRIPTION
This PR introduces two improvements
- configurable classpath argument (currently classpath is equal to the test classpath and users might be using their custom sbt configurations to run cucumber tests what is not supported),
- tags can be passed from code (currently we had to use command aliases to pass them automatically).

Also, I'd like to reiterate a request to publish latest plugin version @lewismj.